### PR TITLE
add cronner LWRP as a drop-in replacement for cron_d LWRP

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,3 +32,11 @@ suites:
       inspec_tests:
         - test/recipes/install_test.rb
     attributes:
+  - name: lwrp
+    provisioner:
+      named_run_list: lwrp
+    verifier:
+      inspec_tests:
+        - test/recipes/install_test.rb
+        - test/recipes/lwrp_test.rb
+    attributes:

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -13,6 +13,11 @@ default_source :supermarket
 run_list "cronner::default"
 
 named_run_list :install, 'cronner::install'
+named_run_list :lwrp, 'cronner_lwrp_test'
 
 # Specify a custom source for a single cookbook:
 cookbook "cronner", path: "."
+cookbook 'cronner_lwrp_test', path: 'test/fixtures/cookbooks/cronner_lwrp_test'
+cookbook 'cron', '~> 3.0.0'
+
+default['cron']['package_name'] = 'cron'

--- a/libraries/lwrp_helpers.rb
+++ b/libraries/lwrp_helpers.rb
@@ -1,0 +1,46 @@
+# Copyright 2017 Tim Heckman <t@heckman.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Cronner
+  module LWRPHelpers
+    def format_string(value)
+      value
+      .gsub(' ', '_')
+    end
+
+    def command_string
+      label format_string(job_name) if label.nil? || label.empty?
+
+      c_str = '/usr/local/bin/cronner '
+
+      c_str << "--label=#{format_string(label)} "
+      c_str << "--namespace=#{format_string(namespace)} " unless namespace.nil? || namespace.empty?
+      c_str << "--event_group=#{format_string(event_group)} " unless event_group.nil? || event_group.empty?
+      c_str << "--metric_group=#{format_string(metric_group)} " unless metric_group.nil? || metric_group.empty?
+
+      c_str << "--warn-after=#{warn_after} " if warn_after > 0
+      c_str << "--wait-secs=#{wait_secs_for_lock} " if lock && wait_secs_for_lock > 0
+
+      c_str << '--event ' if event
+      c_str << '--event-fail ' if event_fail && !event
+      c_str << '--log-fail ' if log_fail
+      c_str << '--lock ' if lock
+      c_str << '--sensitive ' if sensitive_output
+
+      c_str << "-- #{command}"
+
+      c_str
+    end
+  end
+end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,0 +1,119 @@
+#
+# Cookbook Name:: cronner
+# LWRP:: cronner
+#
+# Copyright 2017 Tim Heckman <t@heckman.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource_name :cronner
+default_action :create
+
+property :job_name, String, name_property: true
+
+###
+# cron_d LWRP properties
+#
+property :command, String, required: true
+property :cookbook, String, default: 'cron'
+
+property :predefined_value, String
+property :minute, [String, Integer], default: '*'
+property :hour, [String, Integer], default: '*'
+property :day, [String, Integer], default: '*'
+property :month, [String, Integer], default: '*'
+property :weekday, [String, Integer], default: '*'
+
+property :user, String, default: 'root'
+property :mailto, [String, NilClass]
+property :path, [String, NilClass]
+property :home, [String, NilClass]
+property :shell, [String, NilClass]
+property :comment, [String, NilClass]
+property :environment, [Hash, NilClass], default: {}
+property :mode, [String, Integer], default: '0644'
+
+###
+# cronner properties
+#
+# flag: -e/--event
+property :event, [TrueClass, FalseClass], default: false
+# flag: -E/--event-fail
+property :event_fail, [TrueClass, FalseClass], default: false
+# flag: -F/--log-fail
+property :log_fail, [TrueClass, FalseClass], default: false
+# flag: -G/--event-group
+property :event_group, [String, NilClass], default: nil
+# flag: -g/--group
+# use name metric_group to avoid colliding with group resource
+property :metric_group, [String, NilClass], default: nil
+# flag: -k/--lock
+property :lock, [TrueClass, FalseClass], default: false
+# flag: -l/--label
+property :label, [String, NilClass], default: nil
+# flag: -N/--namespace
+property :namespace, [String, NilClass], default: nil
+# flag: -s/--sensitive
+# use name sensitive_output to avoid colliding with built-in sensitive property
+property :sensitive_output, [TrueClass, FalseClass], default: false
+# flag: -w/--warn-after
+property :warn_after, Integer, default: 0
+# flag: -W/--wait-secs
+property :wait_secs_for_lock, Integer, default: 0
+
+# grab format_string and command_string helper methods
+include Cronner::LWRPHelpers
+
+action :create do
+  include_recipe 'cron'
+
+  cron_d format_string(job_name) do
+    command command_string
+    cookbook new_resource.cookbook
+    minute new_resource.minute
+    hour new_resource.hour
+    day new_resource.day
+    month new_resource.month
+    weekday new_resource.weekday
+    user new_resource.user
+    mailto new_resource.mailto
+    path new_resource.path
+    home new_resource.home
+    shell new_resource.shell
+    comment new_resource.comment
+    environment new_resource.environment
+    mode new_resource.mode
+    action :create
+  end
+end
+
+action :delete do
+  cron_d format_string(job_name) do
+    command command_string
+    cookbook new_resource.cookbook
+    minute new_resource.minute
+    hour new_resource.hour
+    day new_resource.day
+    month new_resource.month
+    weekday new_resource.weekday
+    user new_resource.user
+    mailto new_resource.mailto
+    path new_resource.path
+    home new_resource.home
+    shell new_resource.shell
+    comment new_resource.comment
+    environment new_resource.environment
+    mode new_resource.mode
+    action :delete
+  end
+end

--- a/test/fixtures/cookbooks/cronner_lwrp_test/metadata.rb
+++ b/test/fixtures/cookbooks/cronner_lwrp_test/metadata.rb
@@ -12,17 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name 'cronner'
-version '0.1.0'
+name 'cronner_lwrp_test'
+version '0.0.1'
 license 'Apache 2.0'
-
-description 'Installs/Configures cronner'
-long_description 'Installs/Configures cronner'
 
 maintainer 'Tim Heckman'
 maintainer_email 't@heckman.io'
 
-issues_url 'https://github.com/theckman/cronner/issues' if respond_to?(:issues_url)
-source_url 'https://github.com/theckman/cronner' if respond_to?(:source_url)
+description 'Cookbook for integration tests of the cronner cookbook'
+long_description 'Cookbook for integration tests of the cronner cookbook'
 
-depends 'cron', '~> 3.0.0'
+depends 'cronner'

--- a/test/fixtures/cookbooks/cronner_lwrp_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/cronner_lwrp_test/recipes/default.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: cronner_lwrp_test
+# Recipe:: default
+#
 # Copyright 2017 Tim Heckman <t@heckman.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,17 +16,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name 'cronner'
-version '0.1.0'
-license 'Apache 2.0'
+include_recipe 'cronner'
 
-description 'Installs/Configures cronner'
-long_description 'Installs/Configures cronner'
-
-maintainer 'Tim Heckman'
-maintainer_email 't@heckman.io'
-
-issues_url 'https://github.com/theckman/cronner/issues' if respond_to?(:issues_url)
-source_url 'https://github.com/theckman/cronner' if respond_to?(:source_url)
-
-depends 'cron', '~> 3.0.0'
+cronner 'test job' do
+  command '/bin/true'
+  minute '0'
+  hour '12'
+  event true
+  event_fail true
+  log_fail true
+  event_group 'eventgroup'
+  metric_group 'metricgroup'
+  lock true
+  namespace 'testenv'
+  sensitive_output true
+  warn_after 10
+  wait_secs_for_lock
+end

--- a/test/recipes/lwrp_test.rb
+++ b/test/recipes/lwrp_test.rb
@@ -1,3 +1,5 @@
+# # encoding: utf-8
+#
 # Copyright 2017 Tim Heckman <t@heckman.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,17 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name 'cronner'
-version '0.1.0'
-license 'Apache 2.0'
+# Inspec test for recipe cronner LWRP
 
-description 'Installs/Configures cronner'
-long_description 'Installs/Configures cronner'
-
-maintainer 'Tim Heckman'
-maintainer_email 't@heckman.io'
-
-issues_url 'https://github.com/theckman/cronner/issues' if respond_to?(:issues_url)
-source_url 'https://github.com/theckman/cronner' if respond_to?(:source_url)
-
-depends 'cron', '~> 3.0.0'
+describe file('/etc/cron.d/test_job') do
+  it { should be_file }
+  it { should be_readable }
+  its('owner') { should eql 'root' }
+  its('group') { should eql 'root' }
+  its('content') { should match /^# Crontab for test_job managed by Chef\./ }
+  its('content') do
+    should match %r(^0 12 \* \* \* root /usr/local/bin/cronner --label=test_job --namespace=testenv --event_group=eventgroup --metric_group=metricgroup --warn-after=10 --event --log-fail --lock --sensitive -- /bin/true$)
+  end
+end


### PR DESCRIPTION
This change adds the `cronner` LWRP which is meant to be a drop-in replacement
for the `cron_d` LWRP provided by the `cron` cookbook. Specifically the
`cronner` LWRP wraps the `cron_d` cookbook.

This makes it much easier to replace plain cron jobs with ones wrapped by
`cronner`!