### PR TITLE
update default cronner version to v0.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ including it one of your recipes or by adding it to the `run_list`.
 ### Recipe Attributes
 This cookbook only has one attribute to impact the installation
 (`node['cronner']['default_install_version']`), which takes the cronner version
-string (e.g., `0.4.1`) that you want to have installed.
+string (e.g., `0.4.2`) that you want to have installed.
 
 ## LWRP Usage
 The `cronner` cookbook provides an LWRP to install cron jobs that are monitored

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+default['cronner']['default_install_version'] = '0.4.2'
+
 default['cronner']['known_versions'].tap do |v|
   v['0.4.1']['linux-amd64']['checksum'] = '11cfc853ea484aac75ebe90cafb9b31f8e8ba6fc58bce4ac11d58c63ab5a02ae'
+  v['0.4.2']['linux-amd64']['checksum'] = 'd633bb540371e600180011fdf5ffe9c99a8c2d015d78ada00624239af6909a06'
 end
-
-default['cronner']['default_install_version'] = '0.4.1'

--- a/test/recipes/install_test.rb
+++ b/test/recipes/install_test.rb
@@ -16,11 +16,13 @@
 
 # Inspec test for recipe cronner::install
 
-describe file('/opt/cronner-linux-amd64-v0.4.1') do
+version = '0.4.2'.freeze
+
+describe file("/opt/cronner-linux-amd64-v#{version}") do
   it { should be_directory }
 end
 
-describe file('/opt/cronner-linux-amd64-v0.4.1/cronner') do
+describe file("/opt/cronner-linux-amd64-v#{version}/cronner") do
   it { should be_file }
   it { should be_executable }
   it { should be_readable }
@@ -29,5 +31,5 @@ end
 describe file('/usr/local/bin/cronner') do
   it { should be_file }
   it { should be_symlink }
-  it { should be_linked_to '/opt/cronner-linux-amd64-v0.4.1/cronner' }
+  it { should be_linked_to "/opt/cronner-linux-amd64-v#{version}/cronner" }
 end


### PR DESCRIPTION
This is the latest `cronner` release, so may as well update it to install it by
default.

Signed-off-by: Tim Heckman <t@heckman.io>