### PR TITLE
update source URL; remove uncessary format_string() call; v0.2.3

### DIFF
--- a/libraries/lwrp_helpers.rb
+++ b/libraries/lwrp_helpers.rb
@@ -20,7 +20,7 @@ module Cronner
     end
 
     def command_string
-      label format_string(job_name) if label.nil? || label.empty?
+      label job_name if label.nil? || label.empty?
 
       c_str = '/usr/local/bin/cronner '
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name 'cronner'
-version '0.2.2'
+version '0.2.3'
 license 'Apache 2.0'
 
 description 'Installs/Configures cronner'
@@ -22,7 +22,7 @@ long_description 'Installs/Configures cronner'
 maintainer 'Tim Heckman'
 maintainer_email 't@heckman.io'
 
-issues_url 'https://github.com/theckman/cronner/issues' if respond_to?(:issues_url)
-source_url 'https://github.com/theckman/cronner' if respond_to?(:source_url)
+issues_url 'https://github.com/theckman/cookbook-cronner/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/theckman/cookbook-cronner' if respond_to?(:source_url)
 
 depends 'cron', '~> 3.0.0'


### PR DESCRIPTION
I noticed that I had the wrong URL set for the Source and Issues to be displayed
in the Chef Supermarket UI. Oops. :(

This also makes a change to the `command_string` helper method, in that it
removes an unneeded invocation of `format_string()` when using the resource name
as the label.

Finally, bump to v0.2.3 for release.