### PR TITLE
fix --event-group and --group flag generation; v0.2.4

### DIFF
--- a/libraries/lwrp_helpers.rb
+++ b/libraries/lwrp_helpers.rb
@@ -26,8 +26,8 @@ module Cronner
 
       c_str << "--label=#{format_string(label)} "
       c_str << "--namespace=#{format_string(namespace)} " unless namespace.nil? || namespace.empty?
-      c_str << "--event_group=#{format_string(event_group)} " unless event_group.nil? || event_group.empty?
-      c_str << "--metric_group=#{format_string(metric_group)} " unless metric_group.nil? || metric_group.empty?
+      c_str << "--event-group=#{format_string(event_group)} " unless event_group.nil? || event_group.empty?
+      c_str << "--group=#{format_string(metric_group)} " unless metric_group.nil? || metric_group.empty?
 
       c_str << "--warn-after=#{warn_after} " if warn_after > 0
       c_str << "--wait-secs=#{wait_secs_for_lock} " if lock && wait_secs_for_lock > 0

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name 'cronner'
-version '0.2.3'
+version '0.2.4'
 license 'Apache 2.0'
 
 description 'Installs/Configures cronner'

--- a/test/recipes/lwrp_test.rb
+++ b/test/recipes/lwrp_test.rb
@@ -23,6 +23,6 @@ describe file('/etc/cron.d/test_job') do
   its('group') { should eql 'root' }
   its('content') { should match /^# Crontab for test_job managed by Chef\./ }
   its('content') do
-    should match %r(^0 12 \* \* \* root /usr/local/bin/cronner --label=test_job --namespace=testenv --event_group=eventgroup --metric_group=metricgroup --warn-after=10 --event --log-fail --lock --sensitive -- /bin/true$)
+    should match %r(^0 12 \* \* \* root /usr/local/bin/cronner --label=test_job --namespace=testenv --event-group=eventgroup --group=metricgroup --warn-after=10 --event --log-fail --lock --sensitive -- /bin/true$)
   end
 end


### PR DESCRIPTION
The flags `--event_group` and `--metric_group` just didn't exist. Switch them to
be `--event-group` and `--group` respectively.