### PR TITLE
add support for newer cronner flags

### DIFF
--- a/libraries/lwrp_helpers.rb
+++ b/libraries/lwrp_helpers.rb
@@ -36,6 +36,8 @@ module Cronner
       c_str << '--event-fail ' if event_fail && !event
       c_str << '--log-fail ' if log_fail
       c_str << '--lock ' if lock
+      c_str << '--use-parent ' if use_parent
+      c_str << '--passthru ' if passthru
       c_str << '--sensitive ' if sensitive_output
 
       c_str << "-- #{command}"

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -63,6 +63,10 @@ property :lock, [TrueClass, FalseClass], default: false
 property :label, [String, NilClass], default: nil
 # flag: -N/--namespace
 property :namespace, [String, NilClass], default: nil
+# flag: -p/--passthru
+property :passthru, [TrueClass, FalseClass], default: false
+# flag: -P/--use-parent
+property :use_parent, [TrueClass, FalseClass], default: false
 # flag: -s/--sensitive
 # use name sensitive_output to avoid colliding with built-in sensitive property
 property :sensitive_output, [TrueClass, FalseClass], default: false

--- a/test/fixtures/cookbooks/cronner_lwrp_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/cronner_lwrp_test/recipes/default.rb
@@ -25,6 +25,8 @@ cronner 'test job' do
   event true
   event_fail true
   log_fail true
+  use_parent true
+  passthru true
   event_group 'eventgroup'
   metric_group 'metricgroup'
   lock true

--- a/test/recipes/lwrp_test.rb
+++ b/test/recipes/lwrp_test.rb
@@ -23,6 +23,6 @@ describe file('/etc/cron.d/test_job') do
   its('group') { should eql 'root' }
   its('content') { should match /^# Crontab for test_job managed by Chef\./ }
   its('content') do
-    should match %r(^0 12 \* \* \* root /usr/local/bin/cronner --label=test_job --namespace=testenv --event-group=eventgroup --group=metricgroup --warn-after=10 --event --log-fail --lock --sensitive -- /bin/true$)
+    should match %r(^0 12 \* \* \* root /usr/local/bin/cronner --label=test_job --namespace=testenv --event-group=eventgroup --group=metricgroup --warn-after=10 --event --log-fail --lock --use-parent --passthru --sensitive -- /bin/true$)
   end
 end


### PR DESCRIPTION
This change adds support for the newer boolean cronner flags:

* `-p/--passthru`: send output of command to controlling TTY
* `-P/--use-parent`: if running under `cronner`, include its injected
  environment variables

Signed-off-by: Tim Heckman <t@heckman.io>