### PR TITLE
cronner resource: make sure to use predefined_value property

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -98,6 +98,7 @@ action :create do
     comment new_resource.comment
     environment new_resource.environment
     mode new_resource.mode
+    predefined_value new_resource.predefined_value
     action :create
   end
 end
@@ -119,6 +120,7 @@ action :delete do
     comment new_resource.comment
     environment new_resource.environment
     mode new_resource.mode
+    predefined_value new_resource.predefined_value
     action :delete
   end
 end

--- a/test/fixtures/cookbooks/cronner_lwrp_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/cronner_lwrp_test/recipes/default.rb
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'cronner'
-
 cronner 'test job' do
   command '/bin/true'
   minute '0'
@@ -34,4 +32,21 @@ cronner 'test job' do
   sensitive_output true
   warn_after 10
   wait_secs_for_lock
+end
+
+cronner 'test job two' do
+  command '/bin/true'
+  event true
+  event_fail true
+  log_fail true
+  use_parent true
+  passthru true
+  event_group 'eventgroup'
+  metric_group 'metricgroup'
+  lock true
+  namespace 'testenv'
+  sensitive_output true
+  warn_after 10
+  wait_secs_for_lock
+  predefined_value '@hourly'
 end

--- a/test/recipes/lwrp_test.rb
+++ b/test/recipes/lwrp_test.rb
@@ -26,3 +26,14 @@ describe file('/etc/cron.d/test_job') do
     should match %r(^0 12 \* \* \* root /usr/local/bin/cronner --label=test_job --namespace=testenv --event-group=eventgroup --group=metricgroup --warn-after=10 --event --log-fail --lock --use-parent --passthru --sensitive -- /bin/true$)
   end
 end
+
+describe file('/etc/cron.d/test_job_two') do
+  it { should be_file }
+  it { should be_readable }
+  its('owner') { should eql 'root' }
+  its('group') { should eql 'root' }
+  its('content') { should match /^# Crontab for test_job_two managed by Chef\./ }
+  its('content') do
+    should match %r(^@hourly root /usr/local/bin/cronner --label=test_job_two --namespace=testenv --event-group=eventgroup --group=metricgroup --warn-after=10 --event --log-fail --lock --use-parent --passthru --sensitive -- /bin/true$)
+  end
+end


### PR DESCRIPTION
This fixes a bug in the `cronner` LWRP where the `predefined_property` value
wasn't being passed in the child `cron_d` resource.

This also adds a test to make sure the `predefined_value` property makes it in
to the `cron_d` resource.

Signed-off-by: Tim Heckman <t@heckman.io>