### PR TITLE
add support for installing v0.6.0 & v0.6.1; make v0.6.1 default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default['cronner']['default_install_version'] = '0.5.0'
+default['cronner']['default_install_version'] = '0.6.1'
 
 default['cronner']['known_versions'].tap do |v|
   v['0.4.1']['linux-amd64']['checksum'] = '11cfc853ea484aac75ebe90cafb9b31f8e8ba6fc58bce4ac11d58c63ab5a02ae'
   v['0.4.2']['linux-amd64']['checksum'] = 'd633bb540371e600180011fdf5ffe9c99a8c2d015d78ada00624239af6909a06'
   v['0.5.0']['linux-amd64']['checksum'] = '29de34468bccfaa85c0ce5f1ef887dcd49f1b956625e5deebd44ec0c762f9a4b'
+  v['0.6.0']['linux-amd64']['checksum'] = 'fb2703d9ee7cca4d602edf54ca1b30aa6aab39881ddfea2ad7656964029c7abb'
+  v['0.6.1']['linux-amd64']['checksum'] = '3e874f0ab4fa6fc76548a33e2b048a84dad408c74c68336b114dc0ef26dad590'
 end

--- a/test/recipes/install_test.rb
+++ b/test/recipes/install_test.rb
@@ -16,7 +16,7 @@
 
 # Inspec test for recipe cronner::install
 
-version = '0.5.0'.freeze
+version = '0.6.1'.freeze
 
 describe file("/opt/cronner-linux-amd64-v#{version}") do
   it { should be_directory }


### PR DESCRIPTION
This change adds the checksums needed to install `v0.6.0` and `v0.6.1` of
`cronner`. `v0.6.0` adds support for overriding the DogStatsd host, while
`v0.6.1` is a rebuild of `v0.6.0` against a newer Go runtime version (`v1.7.5`).

This also sets the default installation version to be `v0.6.1`.

Signed-off-by: Tim Heckman <t@heckman.io>