### PR TITLE
Loosen cron dependency

### DIFF
--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -18,6 +18,6 @@ named_run_list :lwrp, 'cronner_lwrp_test'
 # Specify a custom source for a single cookbook:
 cookbook "cronner", path: "."
 cookbook 'cronner_lwrp_test', path: 'test/fixtures/cookbooks/cronner_lwrp_test'
-cookbook 'cron', '~> 3.0.0'
+cookbook 'cron', '~> 5.0'
 
 default['cron']['package_name'] = 'cron'

--- a/metadata.rb
+++ b/metadata.rb
@@ -25,4 +25,4 @@ maintainer_email 't@heckman.io'
 issues_url 'https://github.com/theckman/cookbook-cronner/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/theckman/cookbook-cronner' if respond_to?(:source_url)
 
-depends 'cron', '~> 3.0.0'
+depends 'cron', '~> 5.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,6 +15,7 @@
 name 'cronner'
 version '0.3.4'
 license 'Apache 2.0'
+chef_version '>= 12.7'
 
 description 'Installs/Configures cronner'
 long_description 'Installs/Configures cronner'


### PR DESCRIPTION
While this is potentially dangerous, the `cron` cookbook is depended-upon quite commonly, and pinning it so tightly invites downstream pain to the potential user of this cookbook.

@theckman, in my case, I’ve got `cron ~> 5.0` pinned elsewhere in my systems, so this becomes an impossible dependency solution.

Open to other thoughts!