### PR TITLE
Rename LWRP → Resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,11 +32,11 @@ suites:
       inspec_tests:
         - test/recipes/install_test.rb
     attributes:
-  - name: lwrp
+  - name: resource
     provisioner:
-      named_run_list: lwrp
+      named_run_list: resource
     verifier:
       inspec_tests:
         - test/recipes/install_test.rb
-        - test/recipes/lwrp_test.rb
+        - test/recipes/resource_test.rb
     attributes:

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -13,11 +13,11 @@ default_source :supermarket
 run_list "cronner::default"
 
 named_run_list :install, 'cronner::install'
-named_run_list :lwrp, 'cronner_lwrp_test'
+named_run_list :resource, 'cronner_resource_test'
 
 # Specify a custom source for a single cookbook:
 cookbook "cronner", path: "."
-cookbook 'cronner_lwrp_test', path: 'test/fixtures/cookbooks/cronner_lwrp_test'
+cookbook 'cronner_resource_test', path: 'test/fixtures/cookbooks/cronner_resource_test'
 cookbook 'cron', '~> 3.0.0'
 
 default['cron']['package_name'] = 'cron'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cronner
 
 The `cronner` cookbook installs [cronner](https://github.com/theckman/cronner)
-and provides an LWRP for configuring cron jobs that are wrapped with `cronner`.
-The LWRP is a wrapper of the `cron_d` LWRP and injects the `cronner` invocation
+and provides a custom resource for configuring cron jobs that are wrapped with `cronner`.
+The resource is a wrapper of the `cron_d` resource and injects the `cronner` invocation
 before your command allowing the status and metrics to be collected.
 
 ## License
@@ -22,11 +22,11 @@ This cookbook only has one attribute to impact the installation
 (`node['cronner']['default_install_version']`), which takes the cronner version
 string (e.g., `0.4.2`) that you want to have installed.
 
-## LWRP Usage
-The `cronner` cookbook provides an LWRP to install cron jobs that are monitored
-by `cronner`. This LWRP is a light wrapper around the stellar `cron_d` LWRP from
+## Resource Usage
+The `cronner` cookbook provides a custom resource to install cron jobs that are monitored
+by `cronner`. This resource is a light wrapper around the stellar `cron_d` resource from
 the [cron](https://supermarket.chef.io/cookbooks/cron) cookbook. That means the
-`cronner` LWRP has all the same attributes available as the `cron_d` LWRP. For
+`cronner` resource has all the same attributes available as the `cron_d` resource. For
 information on the `cron_d` resource please view the `Resource and Providers`
 section of the [cron cookbook's](https://supermarket.chef.io/cookbooks/cron)
 README.
@@ -56,8 +56,8 @@ cronner 'db_backup' do
 end
 ```
 
-### Cronner LWRP Attributes
-The LWRP supports either `:create` or `:delete`.
+### Cronner Custom Resource Attributes
+The custom resource supports either `:create` or `:delete`.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module Cronner
-  module LWRPHelpers
+  module Helpers
     def format_string(value)
       value
       .gsub(' ', '_')

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: cronner
-# LWRP:: cronner
+# Resource:: cronner
 #
 # Copyright 2017 Tim Heckman <t@heckman.io>
 #
@@ -22,7 +22,7 @@ default_action :create
 property :job_name, String, name_property: true
 
 ###
-# cron_d LWRP properties
+# cron_d Resource properties
 #
 property :command, String, required: true
 property :cookbook, String, default: 'cron'
@@ -76,7 +76,7 @@ property :warn_after, Integer, default: 0
 property :wait_secs_for_lock, Integer, default: 0
 
 # grab format_string and command_string helper methods
-include Cronner::LWRPHelpers
+include Cronner::Helpers
 
 action :create do
   include_recipe 'cronner'

--- a/test/fixtures/cookbooks/cronner_resource_test/metadata.rb
+++ b/test/fixtures/cookbooks/cronner_resource_test/metadata.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name 'cronner_lwrp_test'
+name 'cronner_resource_test'
 version '0.0.1'
 license 'Apache 2.0'
 

--- a/test/fixtures/cookbooks/cronner_resource_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/cronner_resource_test/recipes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: cronner_lwrp_test
+# Cookbook Name:: cronner_resource_test
 # Recipe:: default
 #
 # Copyright 2017 Tim Heckman <t@heckman.io>

--- a/test/recipes/resource_test.rb
+++ b/test/recipes/resource_test.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Inspec test for recipe cronner LWRP
+# Inspec test for cronner resource
 
 describe file('/etc/cron.d/test_job') do
   it { should be_file }


### PR DESCRIPTION
Because they are now called [Custom Resources](https://docs.chef.io/custom_resources.html).

Based on the structure of this cookbook, it’s always been written as a custom resource? I.e., a single `resources/default.rb`, instead of `resources/default.rb` and `providers/default.rb` (which was how the LWRPs were constructed pre-Chef 12.5).